### PR TITLE
Updating from vulnerable version of bson

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.1.4",
-    "bson": "~1.0.4",
+    "bson": "~2.0.2",
     "kareem": "2.0.5",
     "lodash.get": "4.4.2",
     "mongodb": "3.0.3",


### PR DESCRIPTION
**Summary**
Snyk reported vulnerabilities with current version of bson:

```
Regular Expression Denial of Service (ReDoS)
Vulnerable module: bson
Introduced through: bson@1.0.5 and mongodb@3.0.3
Detailed paths
Introduced through: 
mongoose@Automattic/mongoose#74d33e19f914ed6585f3c318d983866ba6a5df2e › bson@1.0.5
Remediation: Upgrade to bson@2.0.0.
Introduced through: mongoose@Automattic/mongoose#74d33e19f914ed6585f3c318d983866ba6a5df2e › mongodb@3.0.3 › mongodb-core@3.0.3 › bson@1.0.5
```